### PR TITLE
add oncloneForeign option

### DIFF
--- a/src/Clone.js
+++ b/src/Clone.js
@@ -54,6 +54,10 @@ export class DocumentCloner {
         };
         // $FlowFixMe
         this.documentElement = this.cloneNode(element.ownerDocument.documentElement);
+
+        if (this.options.oncloneForeign) {
+            this.options.oncloneForeign(this.documentElement);
+        }
     }
 
     inlineAllImages(node: ?HTMLElement) {

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ export type Options = {
     imageTimeout: number,
     logging: boolean,
     onclone?: Document => void,
+    oncloneForeign?: Node => void,
     proxy: ?string,
     removeContainer: ?boolean,
     scale: number,


### PR DESCRIPTION
Summary

add oncloneForeign option to be applied when using foreignObjectRenderer (same way as onclone option is applied when using the default renderer)

Test plan (required)

when setting onclone option and using foreignObjectRenderer option - the onclone function is not triggered